### PR TITLE
Fixed tmux to install with vanilla brew

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,5 +6,7 @@
 class tmux {
   include homebrew
 
-  package { 'tmux': }
+  package { 'tmux':
+    install_options => ['--nop']
+  }
 }


### PR DESCRIPTION
When I was previously installing tmux without 'install_options' it would
execute 'brew boxen-install tmux', and would not install and link the
proper libevent (the version ending with _1 was missing).  When you
install tmux with any install_options, it will execute 'brew install
tmux' instead, avoiding the incompatibility. I've added a dummy
install_options option since they are ignored by brew if they don't
exist. This is where I got that information:

https://github.com/boxen/puppet-homebrew/blob/153bcc9f7c1245471e45e3a5f6cfa7f8f91fb348/lib/puppet/provider/package/homebrew.rb#L83-L87
